### PR TITLE
fix: Configure classification about access

### DIFF
--- a/client/error.go
+++ b/client/error.go
@@ -97,7 +97,11 @@ func classifyError(err error, fallbackType diag.Type, projects []string, opts ..
 	}
 
 	if es := err.Error(); strings.HasPrefix(es, "google: error getting credentials") || strings.HasPrefix(es, "google: could not find default credentials") {
-		return diag.FromError(err, diag.ACCESS)
+		return diag.Diagnostics{
+			RedactError(projects,
+				diag.NewBaseError(err, diag.ACCESS, append(opts, diag.WithDetails("Please see this document for GCP authentication: https://docs.cloudquery.io/docs/getting-started/getting-started-with-gcp#authenticate-with-gcp"))...),
+			),
+		}
 	}
 
 	// Take over from SDK and always return diagnostics, redacting PII

--- a/client/error.go
+++ b/client/error.go
@@ -96,6 +96,10 @@ func classifyError(err error, fallbackType diag.Type, projects []string, opts ..
 		}
 	}
 
+	if es := err.Error(); strings.HasPrefix(es, "google: error getting credentials") || strings.HasPrefix(es, "google: could not find default credentials") {
+		return diag.FromError(err, diag.ACCESS)
+	}
+
 	// Take over from SDK and always return diagnostics, redacting PII
 	if d, ok := err.(diag.Diagnostic); ok {
 		return diag.Diagnostics{


### PR DESCRIPTION
Fixes #214. The SDK unfortunately uses `fmt.Errorf` and `errors.New` so no other way other than string matching.

too many links?
<img width="1315" alt="Screen Shot 2022-05-02 at 17 51 54 " src="https://user-images.githubusercontent.com/223029/166290368-cabdddab-4c4b-409f-8c20-212ffb4cc38a.png">

