### PR TITLE
fix: Adjusted bigquery error severity when api is disabled

### DIFF
--- a/resources/services/bigquery/bigquery_datasets.go
+++ b/resources/services/bigquery/bigquery_datasets.go
@@ -123,7 +123,7 @@ func fetchBigqueryDatasets(ctx context.Context, meta schema.ClientMeta, parent *
 		list, err := c.RetryingDo(ctx, call)
 		if err != nil {
 			if isAccessErrorToIgnore(err, c.ProjectId) {
-				return diag.FromError(err, diag.USER, diag.WithSeverity(diag.ACCESS),
+				return diag.FromError(err, diag.USER, diag.WithType(diag.ACCESS),
 					diag.WithDetails("Please verify the project id was configured correctly or BigQuery API is enabled in current project. Project names can't be used when fetching BigQuery resources"))
 			}
 			return err

--- a/resources/services/bigquery/bigquery_datasets.go
+++ b/resources/services/bigquery/bigquery_datasets.go
@@ -123,8 +123,8 @@ func fetchBigqueryDatasets(ctx context.Context, meta schema.ClientMeta, parent *
 		list, err := c.RetryingDo(ctx, call)
 		if err != nil {
 			if isProjectIdError(err, c.ProjectId) {
-				return diag.FromError(err, diag.USER,
-					diag.WithDetails("Please verify the project id was configured correctly. Project names can't be used when fetching BigQuery resources"))
+				return diag.FromError(err, diag.USER, diag.WithSeverity(diag.ACCESS),
+					diag.WithDetails("Please verify the project id was configured correctly or BigQuery API is enabled in current project. Project names can't be used when fetching BigQuery resources"))
 			}
 			return err
 		}

--- a/resources/services/bigquery/bigquery_datasets.go
+++ b/resources/services/bigquery/bigquery_datasets.go
@@ -122,7 +122,7 @@ func fetchBigqueryDatasets(ctx context.Context, meta schema.ClientMeta, parent *
 			PageToken(nextPageToken)
 		list, err := c.RetryingDo(ctx, call)
 		if err != nil {
-			if isProjectIdError(err, c.ProjectId) {
+			if isAccessErrorToIgnore(err, c.ProjectId) {
 				return diag.FromError(err, diag.USER, diag.WithSeverity(diag.ACCESS),
 					diag.WithDetails("Please verify the project id was configured correctly or BigQuery API is enabled in current project. Project names can't be used when fetching BigQuery resources"))
 			}
@@ -148,7 +148,7 @@ func fetchBigqueryDatasets(ctx context.Context, meta schema.ClientMeta, parent *
 	return nil
 }
 
-func isProjectIdError(err error, projectId string) bool {
+func isAccessErrorToIgnore(err error, projectId string) bool {
 	var gerr *googleapi.Error
 	if ok := errors.As(err, &gerr); ok {
 		if gerr.Code == http.StatusBadRequest &&

--- a/resources/services/bigquery/bigquery_datasets.go
+++ b/resources/services/bigquery/bigquery_datasets.go
@@ -124,7 +124,7 @@ func fetchBigqueryDatasets(ctx context.Context, meta schema.ClientMeta, parent *
 		if err != nil {
 			if isProjectIdError(err, c.ProjectId) {
 				return diag.FromError(err, diag.USER,
-					diag.WithDetails("Project name might used instead of project id"))
+					diag.WithDetails("Please verify the project id was configured correctly. Project names can't be used when fetching BigQuery resources"))
 			}
 			return err
 		}


### PR DESCRIPTION
…of projectId

🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉

#### Summary

Big query API returns "The project <project_id> has not enabled BigQuery." error with type INVALID_ARGUMENT when user uses project name instead of project id or when API is disabled in project id. API gives this error only in some cases. All the other resources work fine and does not give this kind of error.  
The fix changes the status of error when it happens and adds more details for user.


---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests. Learn more about testing [here](https://docs.cloudquery.io/docs/developers/sdk/testing) 🧪
- [x] Update the docs by running `go run ./docs/docs.go` and committing the changes 📃
- [x] If adding a new resource, add [relevant Terraform files](../terraform) in a separate PR 📂
- [x] Ensure the status checks below are successful ✅
