### PR TITLE
feat: Rollback hit only enabled APIs

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -6,20 +6,14 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"sync"
 	"time"
 
-	"github.com/cloudquery/cq-provider-sdk/helpers"
-	"github.com/cloudquery/cq-provider-sdk/helpers/limit"
 	"github.com/cloudquery/cq-provider-sdk/provider/diag"
 	"github.com/cloudquery/cq-provider-sdk/provider/schema"
 	"github.com/hashicorp/go-hclog"
-	"golang.org/x/sync/errgroup"
-	"golang.org/x/sync/semaphore"
 	crmv1 "google.golang.org/api/cloudresourcemanager/v1"
 	"google.golang.org/api/cloudresourcemanager/v3"
 	"google.golang.org/api/option"
-	"google.golang.org/api/serviceusage/v1"
 )
 
 const defaultProjectIdName = "<CHANGE_THIS_TO_YOUR_PROJECT_ID>"
@@ -35,17 +29,14 @@ type Client struct {
 	Services *Services
 	// this is set by table client multiplexer
 	ProjectId string
-	// List of enabled services per project
-	EnabledServices map[string]map[GcpService]bool
 }
 
 func NewGcpClient(log hclog.Logger, bo BackoffSettings, projects []string, services *Services) *Client {
 	c := &Client{
-		projects:        projects,
-		logger:          log,
-		backoff:         bo,
-		Services:        services,
-		EnabledServices: make(map[string]map[GcpService]bool),
+		projects: projects,
+		logger:   log,
+		backoff:  bo,
+		Services: services,
 	}
 	if len(projects) == 1 {
 		c.ProjectId = projects[0]
@@ -64,57 +55,6 @@ func (c Client) withProject(project string) *Client {
 	c.logger = c.logger.With("project_id", project)
 	c.ProjectId = project
 	return &c
-}
-
-func (c *Client) configureEnabledServices() diag.Diagnostics {
-	var esLock sync.Mutex
-	var diags diag.Diagnostics
-	g, ctx := errgroup.WithContext(context.Background())
-	maxGoroutines := limit.GetMaxGoRoutines()
-	goroutinesSem := semaphore.NewWeighted(helpers.Uint64ToInt64(maxGoroutines))
-	for _, p := range c.projects {
-		project := p
-		if err := goroutinesSem.Acquire(ctx, 1); err != nil {
-			return diags.Add(diag.WrapError(err))
-		}
-		g.Go(func() error {
-			defer goroutinesSem.Release(1)
-			cl := c.withProject(project)
-			svc, err := cl.fetchEnabledServices(ctx)
-			esLock.Lock()
-			if err != nil {
-				c.logger.Warn("failed to fetch enabled services", "project_id", project, "error", err)
-				diags = diags.Add(classifyError(err, diag.INTERNAL, c.projects, diag.WithSeverity(diag.Severity(diag.INTERNAL)), diag.WithSummary("failed to fetch enabled services for project=%s", project)))
-			} else {
-				c.EnabledServices[project] = svc
-			}
-			esLock.Unlock()
-			return err
-		})
-	}
-	return diags.Add(g.Wait())
-}
-
-func (c *Client) fetchEnabledServices(ctx context.Context) (map[GcpService]bool, error) {
-	enabled := make(map[GcpService]bool)
-	nextPageToken := ""
-	for {
-		call := c.Services.ServiceUsage.Services.List(fmt.Sprintf("projects/%s", c.ProjectId))
-		call = call.Filter("state:ENABLED").PageSize(200).PageToken(nextPageToken)
-		list, err := c.RetryingDo(ctx, call)
-		if err != nil {
-			return nil, diag.WrapError(err)
-		}
-		output := list.(*serviceusage.ListServicesResponse)
-		for _, item := range output.Services {
-			enabled[GcpService(item.Config.Name)] = true
-		}
-		if output.NextPageToken == "" {
-			break
-		}
-		nextPageToken = output.NextPageToken
-	}
-	return enabled, nil
 }
 
 func isValidJson(content []byte) error {
@@ -200,8 +140,7 @@ func Configure(logger hclog.Logger, config interface{}) (schema.ClientMeta, diag
 	}
 
 	client := NewGcpClient(logger, providerConfig.Backoff(), projects, services)
-	// we just add diags in case configureEnabledServices failed
-	diags = diags.Add(client.configureEnabledServices())
+
 	return client, diags
 }
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -9,14 +9,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/cloudquery/cq-provider-sdk/logging"
 	"github.com/cloudquery/faker/v3"
 	"github.com/hashicorp/go-hclog"
 	"github.com/julienschmidt/httprouter"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/api/cloudresourcemanager/v3"
 	"google.golang.org/api/option"
-	"google.golang.org/api/serviceusage/v1"
 )
 
 func TestAppendWithoutDupes(t *testing.T) {
@@ -129,69 +127,4 @@ func mockCRMFolders() (*cloudresourcemanager.FoldersService, error) {
 		return nil, err
 	}
 	return svc.Folders, nil
-}
-
-func mockServiceusageService(t *testing.T, name, state string) *serviceusage.GoogleApiServiceusageV1Service {
-	var service serviceusage.GoogleApiServiceusageV1Service
-	if err := faker.FakeDataSkipFields(&service, []string{"Config"}); err != nil {
-		t.Fatal(err)
-	}
-	service.State = state
-	service.Config = &serviceusage.GoogleApiServiceusageV1ServiceConfig{}
-	if err := faker.FakeDataSkipFields(service.Config, []string{"Documentation"}); err != nil {
-		t.Fatal(err)
-	}
-	service.Config.Name = name
-	service.Config.Documentation = &serviceusage.Documentation{}
-	service.Config.Apis[0].Methods[0].Options[0].Value = []byte("{}")
-	service.Config.Apis[0].Options[0].Value = []byte("{}")
-	if err := faker.FakeDataSkipFields(service.Config.Documentation, []string{"Pages"}); err != nil {
-		t.Fatal(err)
-	}
-	return &service
-}
-
-func createServices(t *testing.T) *Services {
-	ctx := context.Background()
-	service := mockServiceusageService(t, "service1", "ENABLED")
-	mux := httprouter.New()
-	mux.GET("/v1/projects/project1/services", func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
-		resp := &serviceusage.ListServicesResponse{
-			Services: []*serviceusage.GoogleApiServiceusageV1Service{service},
-		}
-		b, err := json.Marshal(resp)
-		if err != nil {
-			http.Error(w, "unable to marshal request: "+err.Error(), http.StatusBadRequest)
-			return
-		}
-		if _, err := w.Write(b); err != nil {
-			http.Error(w, "failed to write", http.StatusBadRequest)
-			return
-		}
-	})
-
-	ts := httptest.NewServer(mux)
-	svc, err := serviceusage.NewService(ctx, option.WithoutAuthentication(), option.WithEndpoint(ts.URL))
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(ts.Close)
-	return &Services{
-		ServiceUsage: svc,
-	}
-}
-
-func TestClient_configureEnabledServices(t *testing.T) {
-	cl := NewGcpClient(
-		logging.New(&hclog.LoggerOptions{
-			Level: hclog.Warn,
-		}),
-		BackoffSettings{},
-		[]string{"project1"},
-		createServices(t),
-	)
-	assert.True(t, !cl.configureEnabledServices().HasErrors())
-	assert.Equal(t, map[string]map[GcpService]bool{
-		"project1": {"service1": true},
-	}, cl.EnabledServices)
 }

--- a/client/multiplex.go
+++ b/client/multiplex.go
@@ -13,23 +13,3 @@ func ProjectMultiplex(meta schema.ClientMeta) []schema.ClientMeta {
 	}
 	return l
 }
-
-// ProjectMultiplexEnabledAPIs returns a project multiplexer but filters those project who have disabled apis
-func ProjectMultiplexEnabledAPIs(enabledService GcpService) func(schema.ClientMeta) []schema.ClientMeta {
-	return func(meta schema.ClientMeta) []schema.ClientMeta {
-		cl := meta.(*Client)
-
-		// preallocate all clients just in case
-		l := make([]schema.ClientMeta, 0, len(cl.projects))
-		for _, projectId := range cl.projects {
-			if cl.EnabledServices[projectId] == nil {
-				// this means we didn't have permissions to list the enabled apis so we will try to hit all of them
-				l = append(l, cl.withProject(projectId))
-			} else if cl.EnabledServices[projectId][enabledService] {
-				// this means we have permissions to list the enabled apis so we will only hit those who are enabled
-				l = append(l, cl.withProject(projectId))
-			}
-		}
-		return l
-	}
-}

--- a/client/testing.go
+++ b/client/testing.go
@@ -32,23 +32,6 @@ func GcpMockTestHelper(t *testing.T, table *schema.Table, createService func() (
 				c := NewGcpClient(logging.New(&hclog.LoggerOptions{
 					Level: hclog.Warn,
 				}), BackoffSettings{}, []string{"testProject"}, svc)
-				c.EnabledServices = map[string]map[GcpService]bool{
-					"testProject": {
-						BigQueryService:             true,
-						CloudBillingService:         true,
-						CloudFunctionsService:       true,
-						CloudKmsService:             true,
-						CloudResourceManagerService: true,
-						ComputeService:              true,
-						DnsService:                  true,
-						DomainsService:              true,
-						IamService:                  true,
-						LoggingService:              true,
-						MonitoringService:           true,
-						SqlAdminService:             true,
-						StorageService:              true,
-					},
-				}
 				return c, nil
 			},
 			ResourceMap: map[string]*schema.Table{

--- a/resources/services/bigquery/bigquery_datasets.go
+++ b/resources/services/bigquery/bigquery_datasets.go
@@ -19,7 +19,7 @@ func BigqueryDatasets() *schema.Table {
 		Description:  "dataset resources in the project",
 		Resolver:     fetchBigqueryDatasets,
 		IgnoreError:  client.IgnoreErrorHandler,
-		Multiplex:    client.ProjectMultiplexEnabledAPIs(client.BigQueryService),
+		Multiplex:    client.ProjectMultiplex,
 		DeleteFilter: client.DeleteProjectFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"project_id", "id"}},
 		Columns: []schema.Column{

--- a/resources/services/cloudbilling/accounts.go
+++ b/resources/services/cloudbilling/accounts.go
@@ -23,7 +23,7 @@ func Accounts() *schema.Table {
 	return &schema.Table{
 		Name:          "gcp_cloudbilling_accounts",
 		Resolver:      fetchBillingAccounts,
-		Multiplex:     client.ProjectMultiplexEnabledAPIs(client.CloudBillingService),
+		Multiplex:     client.ProjectMultiplex,
 		IgnoreError:   client.IgnoreErrorHandler,
 		DeleteFilter:  client.DeleteProjectFilter,
 		Options:       schema.TableCreationOptions{PrimaryKeys: []string{"project_id", "name"}},

--- a/resources/services/cloudfunctions/cloudfunctions_function.go
+++ b/resources/services/cloudfunctions/cloudfunctions_function.go
@@ -14,7 +14,7 @@ func CloudfunctionsFunction() *schema.Table {
 		Name:         "gcp_cloudfunctions_functions",
 		Description:  "Describes a Cloud Function that contains user computation executed in response to an event It encapsulate function and triggers configurations",
 		Resolver:     fetchCloudfunctionsFunctions,
-		Multiplex:    client.ProjectMultiplexEnabledAPIs(client.CloudFunctionsService),
+		Multiplex:    client.ProjectMultiplex,
 		IgnoreError:  client.IgnoreErrorHandler,
 		DeleteFilter: client.DeleteProjectFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"project_id", "name"}},

--- a/resources/services/compute/compute_addresses.go
+++ b/resources/services/compute/compute_addresses.go
@@ -15,7 +15,7 @@ func ComputeAddresses() *schema.Table {
 		Description:  "Addresses for GFE-based external HTTP(S) load balancers.",
 		Resolver:     fetchComputeAddresses,
 		IgnoreError:  client.IgnoreErrorHandler,
-		Multiplex:    client.ProjectMultiplexEnabledAPIs(client.ComputeService),
+		Multiplex:    client.ProjectMultiplex,
 		DeleteFilter: client.DeleteProjectFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"project_id", "id"}},
 		Columns: []schema.Column{

--- a/resources/services/compute/compute_autoscalers.go
+++ b/resources/services/compute/compute_autoscalers.go
@@ -15,7 +15,7 @@ func ComputeAutoscalers() *schema.Table {
 		Description:  "Represents an Autoscaler resource.",
 		Resolver:     fetchComputeAutoscalers,
 		IgnoreError:  client.IgnoreErrorHandler,
-		Multiplex:    client.ProjectMultiplexEnabledAPIs(client.ComputeService),
+		Multiplex:    client.ProjectMultiplex,
 		DeleteFilter: client.DeleteProjectFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"project_id", "id"}},
 		Columns: []schema.Column{

--- a/resources/services/compute/compute_backend_services.go
+++ b/resources/services/compute/compute_backend_services.go
@@ -17,7 +17,7 @@ func ComputeBackendServices() *schema.Table {
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"project_id", "id"}},
 		IgnoreError:  client.IgnoreErrorHandler,
 		Resolver:     fetchComputeBackendServices,
-		Multiplex:    client.ProjectMultiplexEnabledAPIs(client.ComputeService),
+		Multiplex:    client.ProjectMultiplex,
 		DeleteFilter: client.DeleteProjectFilter,
 		Columns: []schema.Column{
 			{

--- a/resources/services/compute/compute_disk_types.go
+++ b/resources/services/compute/compute_disk_types.go
@@ -18,7 +18,7 @@ func ComputeDiskTypes() *schema.Table {
 		Description:  "Represents a Disk Type resource.",
 		Resolver:     fetchComputeDiskTypes,
 		IgnoreError:  client.IgnoreErrorHandler,
-		Multiplex:    client.ProjectMultiplexEnabledAPIs(client.ComputeService),
+		Multiplex:    client.ProjectMultiplex,
 		DeleteFilter: client.DeleteProjectFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"project_id", "id"}},
 		Columns: []schema.Column{

--- a/resources/services/compute/compute_disks.go
+++ b/resources/services/compute/compute_disks.go
@@ -15,7 +15,7 @@ func ComputeDisks() *schema.Table {
 		Description:  "Represents a Persistent Disk resource.",
 		Resolver:     fetchComputeDisks,
 		IgnoreError:  client.IgnoreErrorHandler,
-		Multiplex:    client.ProjectMultiplexEnabledAPIs(client.ComputeService),
+		Multiplex:    client.ProjectMultiplex,
 		DeleteFilter: client.DeleteProjectFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"project_id", "id"}},
 		Columns: []schema.Column{

--- a/resources/services/compute/compute_forwarding_rules.go
+++ b/resources/services/compute/compute_forwarding_rules.go
@@ -14,7 +14,7 @@ func ComputeForwardingRules() *schema.Table {
 		Name:         "gcp_compute_forwarding_rules",
 		Description:  "Represents a Forwarding Rule resource  Forwarding rule resources in GCP can be either regional or global.",
 		Resolver:     fetchComputeForwardingRules,
-		Multiplex:    client.ProjectMultiplexEnabledAPIs(client.ComputeService),
+		Multiplex:    client.ProjectMultiplex,
 		IgnoreError:  client.IgnoreErrorHandler,
 		DeleteFilter: client.DeleteProjectFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"project_id", "id"}},

--- a/resources/services/compute/compute_images.go
+++ b/resources/services/compute/compute_images.go
@@ -14,7 +14,7 @@ func ComputeImages() *schema.Table {
 		Name:         "gcp_compute_images",
 		Description:  "Represents an Image resource  You can use images to create boot disks for your VM instances",
 		Resolver:     fetchComputeImages,
-		Multiplex:    client.ProjectMultiplexEnabledAPIs(client.ComputeService),
+		Multiplex:    client.ProjectMultiplex,
 		IgnoreError:  client.IgnoreErrorHandler,
 		DeleteFilter: client.DeleteProjectFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"project_id", "id"}},

--- a/resources/services/compute/compute_instances.go
+++ b/resources/services/compute/compute_instances.go
@@ -14,7 +14,7 @@ func ComputeInstances() *schema.Table {
 		Name:         "gcp_compute_instances",
 		Description:  "Represents an Instance resource  An instance is a virtual machine that is hosted on Google Cloud Platform For more information, read Virtual Machine Instances",
 		Resolver:     fetchComputeInstances,
-		Multiplex:    client.ProjectMultiplexEnabledAPIs(client.ComputeService),
+		Multiplex:    client.ProjectMultiplex,
 		IgnoreError:  client.IgnoreErrorHandler,
 		DeleteFilter: client.DeleteProjectFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"project_id", "id"}},

--- a/resources/services/compute/compute_interconnects.go
+++ b/resources/services/compute/compute_interconnects.go
@@ -14,7 +14,7 @@ func ComputeInterconnects() *schema.Table {
 		Name:          "gcp_compute_interconnects",
 		Description:   "Represents an Interconnect resource  An Interconnect resource is a dedicated connection between the GCP network and your on-premises network",
 		Resolver:      fetchComputeInterconnects,
-		Multiplex:     client.ProjectMultiplexEnabledAPIs(client.ComputeService),
+		Multiplex:     client.ProjectMultiplex,
 		IgnoreError:   client.IgnoreErrorHandler,
 		DeleteFilter:  client.DeleteProjectFilter,
 		Options:       schema.TableCreationOptions{PrimaryKeys: []string{"project_id", "id"}},

--- a/resources/services/compute/compute_networks.go
+++ b/resources/services/compute/compute_networks.go
@@ -14,7 +14,7 @@ func ComputeNetworks() *schema.Table {
 		Name:         "gcp_compute_networks",
 		Description:  "Represents a VPC Network resource  Networks connect resources to each other and to the internet",
 		Resolver:     fetchComputeNetworks,
-		Multiplex:    client.ProjectMultiplexEnabledAPIs(client.ComputeService),
+		Multiplex:    client.ProjectMultiplex,
 		IgnoreError:  client.IgnoreErrorHandler,
 		DeleteFilter: client.DeleteProjectFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"project_id", "id"}},

--- a/resources/services/compute/compute_projects.go
+++ b/resources/services/compute/compute_projects.go
@@ -14,7 +14,7 @@ func ComputeProjects() *schema.Table {
 		Name:         "gcp_compute_projects",
 		Description:  "Represents a Project resource which is used to organize resources in a Google Cloud Platform environment",
 		Resolver:     fetchComputeProjects,
-		Multiplex:    client.ProjectMultiplexEnabledAPIs(client.ComputeService),
+		Multiplex:    client.ProjectMultiplex,
 		IgnoreError:  client.IgnoreErrorHandler,
 		DeleteFilter: client.DeleteProjectFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"project_id"}},

--- a/resources/services/compute/compute_ssl_certificates.go
+++ b/resources/services/compute/compute_ssl_certificates.go
@@ -14,7 +14,7 @@ func ComputeSslCertificates() *schema.Table {
 		Name:         "gcp_compute_ssl_certificates",
 		Description:  "Represents an SSL Certificate resource.",
 		Resolver:     fetchComputeSslCertificates,
-		Multiplex:    client.ProjectMultiplexEnabledAPIs(client.ComputeService),
+		Multiplex:    client.ProjectMultiplex,
 		IgnoreError:  client.IgnoreErrorHandler,
 		DeleteFilter: client.DeleteProjectFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"project_id", "id"}},

--- a/resources/services/compute/compute_ssl_policies.go
+++ b/resources/services/compute/compute_ssl_policies.go
@@ -14,7 +14,7 @@ func ComputeSslPolicies() *schema.Table {
 		Name:         "gcp_compute_ssl_policies",
 		Description:  "Represents an SSL Policy resource",
 		Resolver:     fetchComputeSslPolicies,
-		Multiplex:    client.ProjectMultiplexEnabledAPIs(client.ComputeService),
+		Multiplex:    client.ProjectMultiplex,
 		IgnoreError:  client.IgnoreErrorHandler,
 		DeleteFilter: client.DeleteProjectFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"project_id", "id"}},

--- a/resources/services/compute/compute_subnetworks.go
+++ b/resources/services/compute/compute_subnetworks.go
@@ -14,7 +14,7 @@ func ComputeSubnetworks() *schema.Table {
 		Name:         "gcp_compute_subnetworks",
 		Description:  "Represents a Subnetwork resource  A subnetwork (also known as a subnet) is a logical partition of a Virtual Private Cloud network with one primary IP range and zero or more secondary IP ranges",
 		Resolver:     fetchComputeSubnetworks,
-		Multiplex:    client.ProjectMultiplexEnabledAPIs(client.ComputeService),
+		Multiplex:    client.ProjectMultiplex,
 		IgnoreError:  client.IgnoreErrorHandler,
 		DeleteFilter: client.DeleteProjectFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"project_id", "id"}},

--- a/resources/services/compute/compute_target_http_proxies.go
+++ b/resources/services/compute/compute_target_http_proxies.go
@@ -14,7 +14,7 @@ func ComputeTargetHTTPProxies() *schema.Table {
 		Name:         "gcp_compute_target_http_proxies",
 		Description:  "Represents a Target HTTP Proxy resource",
 		Resolver:     fetchComputeTargetHttpProxies,
-		Multiplex:    client.ProjectMultiplexEnabledAPIs(client.ComputeService),
+		Multiplex:    client.ProjectMultiplex,
 		IgnoreError:  client.IgnoreErrorHandler,
 		DeleteFilter: client.DeleteProjectFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"project_id", "id"}},

--- a/resources/services/compute/compute_target_https_proxies.go
+++ b/resources/services/compute/compute_target_https_proxies.go
@@ -14,7 +14,7 @@ func ComputeTargetHTTPSProxies() *schema.Table {
 		Name:         "gcp_compute_target_https_proxies",
 		Description:  "Represents a Target HTTPS Proxy resource",
 		Resolver:     fetchComputeTargetHttpsProxies,
-		Multiplex:    client.ProjectMultiplexEnabledAPIs(client.ComputeService),
+		Multiplex:    client.ProjectMultiplex,
 		IgnoreError:  client.IgnoreErrorHandler,
 		DeleteFilter: client.DeleteProjectFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"project_id", "id"}},

--- a/resources/services/compute/compute_target_ssl_proxies.go
+++ b/resources/services/compute/compute_target_ssl_proxies.go
@@ -14,7 +14,7 @@ func ComputeTargetSslProxies() *schema.Table {
 		Name:         "gcp_compute_target_ssl_proxies",
 		Description:  "Represents a Target SSL Proxy resource",
 		Resolver:     fetchComputeTargetSslProxies,
-		Multiplex:    client.ProjectMultiplexEnabledAPIs(client.ComputeService),
+		Multiplex:    client.ProjectMultiplex,
 		IgnoreError:  client.IgnoreErrorHandler,
 		DeleteFilter: client.DeleteProjectFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"project_id", "id"}},

--- a/resources/services/compute/compute_url_maps.go
+++ b/resources/services/compute/compute_url_maps.go
@@ -15,7 +15,7 @@ func ComputeURLMaps() *schema.Table {
 		Name:         "gcp_compute_url_maps",
 		Description:  "Represents a URL Map resource",
 		Resolver:     fetchComputeUrlMaps,
-		Multiplex:    client.ProjectMultiplexEnabledAPIs(client.ComputeService),
+		Multiplex:    client.ProjectMultiplex,
 		IgnoreError:  client.IgnoreErrorHandler,
 		DeleteFilter: client.DeleteProjectFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"project_id", "id"}},

--- a/resources/services/compute/compute_vpn_gateways.go
+++ b/resources/services/compute/compute_vpn_gateways.go
@@ -15,7 +15,7 @@ func ComputeVpnGateways() *schema.Table {
 		Description:   "Represents a HA VPN gateway  HA VPN is a high-availability (HA) Cloud VPN solution that lets you securely connect your on-premises network to your Google Cloud Virtual Private Cloud network through an IPsec VPN connection in a single region.",
 		Resolver:      fetchComputeVpnGateways,
 		Options:       schema.TableCreationOptions{PrimaryKeys: []string{"project_id", "id"}},
-		Multiplex:     client.ProjectMultiplexEnabledAPIs(client.ComputeService),
+		Multiplex:     client.ProjectMultiplex,
 		IgnoreError:   client.IgnoreErrorHandler,
 		DeleteFilter:  client.DeleteProjectFilter,
 		IgnoreInTests: true,

--- a/resources/services/compute/instance_groups.go
+++ b/resources/services/compute/instance_groups.go
@@ -17,7 +17,7 @@ func InstanceGroups() *schema.Table {
 		Description:  "Represents an Instance Group resource",
 		Resolver:     fetchComputeInstanceGroups,
 		IgnoreError:  client.IgnoreErrorHandler,
-		Multiplex:    client.ProjectMultiplexEnabledAPIs(client.ComputeService),
+		Multiplex:    client.ProjectMultiplex,
 		DeleteFilter: client.DeleteProjectFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"project_id", "id"}},
 		Columns: []schema.Column{

--- a/resources/services/dns/dns_managed_zones.go
+++ b/resources/services/dns/dns_managed_zones.go
@@ -14,7 +14,7 @@ func DNSManagedZones() *schema.Table {
 		Name:         "gcp_dns_managed_zones",
 		Description:  "A zone is a subtree of the DNS namespace under one administrative responsibility A ManagedZone is a resource that represents a DNS zone hosted by the Cloud DNS service",
 		Resolver:     fetchDnsManagedZones,
-		Multiplex:    client.ProjectMultiplexEnabledAPIs(client.DnsService),
+		Multiplex:    client.ProjectMultiplex,
 		IgnoreError:  client.IgnoreErrorHandler,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"project_id", "id"}},
 		DeleteFilter: client.DeleteProjectFilter,

--- a/resources/services/dns/dns_policies.go
+++ b/resources/services/dns/dns_policies.go
@@ -14,7 +14,7 @@ func DNSPolicies() *schema.Table {
 		Name:         "gcp_dns_policies",
 		Description:  "A policy is a collection of DNS rules applied to one or more Virtual Private Cloud resources",
 		Resolver:     fetchDnsPolicies,
-		Multiplex:    client.ProjectMultiplexEnabledAPIs(client.DnsService),
+		Multiplex:    client.ProjectMultiplex,
 		IgnoreError:  client.IgnoreErrorHandler,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"project_id", "id"}},
 		DeleteFilter: client.DeleteProjectFilter,

--- a/resources/services/domains/domains_registration.go
+++ b/resources/services/domains/domains_registration.go
@@ -16,7 +16,7 @@ func DomainsRegistration() *schema.Table {
 		Name:          "gcp_domains_registrations",
 		Description:   "The `Registration` resource facilitates managing and configuring domain name registrations To create a new `Registration` resource, find a suitable domain name by calling the `SearchDomains` method with a query to see available domain name options After choosing a name, call `RetrieveRegisterParameters` to ensure availability and obtain information like pricing, which is needed to build a call to `RegisterDomain`",
 		Resolver:      fetchDomainsRegistrations,
-		Multiplex:     client.ProjectMultiplexEnabledAPIs(client.DomainsService),
+		Multiplex:     client.ProjectMultiplex,
 		IgnoreError:   client.IgnoreErrorHandler,
 		DeleteFilter:  client.DeleteProjectFilter,
 		Options:       schema.TableCreationOptions{PrimaryKeys: []string{"project_id", "name"}},

--- a/resources/services/iam/iam_roles.go
+++ b/resources/services/iam/iam_roles.go
@@ -14,7 +14,7 @@ func IamRoles() *schema.Table {
 		Name:         "gcp_iam_roles",
 		Description:  "A role in the Identity and Access Management API",
 		Resolver:     fetchIamRoles,
-		Multiplex:    client.ProjectMultiplexEnabledAPIs(client.IamService),
+		Multiplex:    client.ProjectMultiplex,
 		DeleteFilter: client.DeleteProjectFilter,
 		IgnoreError:  client.IgnoreErrorHandler,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"project_id", "name"}},

--- a/resources/services/iam/iam_service_accounts.go
+++ b/resources/services/iam/iam_service_accounts.go
@@ -14,7 +14,7 @@ func IamServiceAccounts() *schema.Table {
 		Name:         "gcp_iam_service_accounts",
 		Description:  "An IAM service account A service account is an account for an application or a virtual machine (VM) instance, not a person You can use a service account to call Google APIs To learn more, read the overview of service accounts (https://cloudgooglecom/iam/help/service-accounts/overview) When you create a service account, you specify the project ID that owns the service account, as well as a name that must be unique within the project IAM uses these values to create an email address that identifies the service account",
 		Resolver:     fetchIamServiceAccounts,
-		Multiplex:    client.ProjectMultiplexEnabledAPIs(client.IamService),
+		Multiplex:    client.ProjectMultiplex,
 		IgnoreError:  client.IgnoreErrorHandler,
 		DeleteFilter: client.DeleteProjectFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"project_id", "id"}},

--- a/resources/services/kms/kms_keyrings.go
+++ b/resources/services/kms/kms_keyrings.go
@@ -21,7 +21,7 @@ func KmsKeyrings() *schema.Table {
 		Name:                 "gcp_kms_keyrings",
 		Description:          "A KeyRing is a toplevel logical grouping of CryptoKeys.",
 		Resolver:             fetchKmsKeyrings,
-		Multiplex:            client.ProjectMultiplexEnabledAPIs(client.CloudKmsService),
+		Multiplex:            client.ProjectMultiplex,
 		IgnoreError:          client.IgnoreErrorHandler,
 		DeleteFilter:         client.DeleteProjectFilter,
 		PostResourceResolver: client.AddGcpMetadata,

--- a/resources/services/logging/logging_metrics.go
+++ b/resources/services/logging/logging_metrics.go
@@ -15,7 +15,7 @@ func LoggingMetrics() *schema.Table {
 		Name:         "gcp_logging_metrics",
 		Description:  "Describes a logs-based metric The value of the metric is the number of log entries that match a logs filter in a given time intervalLogs-based metrics can also be used to extract values from logs and create a distribution of the values The distribution records the statistics of the extracted values along with an optional histogram of the values as specified by the bucket options",
 		Resolver:     fetchLoggingMetrics,
-		Multiplex:    client.ProjectMultiplexEnabledAPIs(client.LoggingService),
+		Multiplex:    client.ProjectMultiplex,
 		IgnoreError:  client.IgnoreErrorHandler,
 		DeleteFilter: client.DeleteProjectFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"project_id", "name"}},

--- a/resources/services/logging/logging_sinks.go
+++ b/resources/services/logging/logging_sinks.go
@@ -15,7 +15,7 @@ func LoggingSinks() *schema.Table {
 		Name:         "gcp_logging_sinks",
 		Description:  "Describes a sink used to export log entries to one of the following destinations in any project: a Cloud Storage bucket, a BigQuery dataset, a Cloud Pub/Sub topic or a Cloud Logging Bucket A logs filter controls which log entries are exported The sink must be created within a project, organization, billing account, or folder",
 		Resolver:     fetchLoggingSinks,
-		Multiplex:    client.ProjectMultiplexEnabledAPIs(client.LoggingService),
+		Multiplex:    client.ProjectMultiplex,
 		IgnoreError:  client.IgnoreErrorHandler,
 		DeleteFilter: client.DeleteProjectFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"project_id", "name"}},

--- a/resources/services/monitoring/monitoring_alert_policies.go
+++ b/resources/services/monitoring/monitoring_alert_policies.go
@@ -15,7 +15,7 @@ func MonitoringAlertPolicies() *schema.Table {
 		Name:         "gcp_monitoring_alert_policies",
 		Description:  "A description of the conditions under which some aspect of your system is considered to be \"unhealthy\" and the ways to notify people or services about this state For an overview of alert policies, see Introduction to Alerting (https://cloudgooglecom/monitoring/alerts/)",
 		Resolver:     fetchMonitoringAlertPolicies,
-		Multiplex:    client.ProjectMultiplexEnabledAPIs(client.MonitoringService),
+		Multiplex:    client.ProjectMultiplex,
 		IgnoreError:  client.IgnoreErrorHandler,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"project_id", "name"}},
 		DeleteFilter: client.DeleteProjectFilter,

--- a/resources/services/resource_manager/resource_manager_folders.go
+++ b/resources/services/resource_manager/resource_manager_folders.go
@@ -15,7 +15,7 @@ func ResourceManagerFolders() *schema.Table {
 		Name:          "gcp_resource_manager_folders",
 		Description:   "A folder in an organization's resource hierarchy, used to organize that organization's resources",
 		Resolver:      fetchResourceManagerFolders,
-		Multiplex:     client.ProjectMultiplexEnabledAPIs(client.CloudResourceManagerService),
+		Multiplex:     client.ProjectMultiplex,
 		IgnoreError:   client.IgnoreErrorHandler,
 		Options:       schema.TableCreationOptions{PrimaryKeys: []string{"project_id", "name"}},
 		DeleteFilter:  client.DeleteProjectFilter,

--- a/resources/services/resource_manager/resource_manager_projects.go
+++ b/resources/services/resource_manager/resource_manager_projects.go
@@ -15,7 +15,7 @@ func ResourceManagerProjects() *schema.Table {
 		Name:         "gcp_resource_manager_projects",
 		Description:  "A project is a high-level Google Cloud entity It is a container for ACLs, APIs, App Engine Apps, VMs, and other Google Cloud Platform resources",
 		Resolver:     fetchResourceManagerProjects,
-		Multiplex:    client.ProjectMultiplexEnabledAPIs(client.CloudResourceManagerService),
+		Multiplex:    client.ProjectMultiplex,
 		IgnoreError:  client.IgnoreErrorHandler,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"project_id", "name"}},
 		DeleteFilter: client.DeleteProjectFilter,

--- a/resources/services/sql/sql_instances.go
+++ b/resources/services/sql/sql_instances.go
@@ -14,7 +14,7 @@ func SQLInstances() *schema.Table {
 		Name:         "gcp_sql_instances",
 		Description:  "A Cloud SQL instance resource",
 		Resolver:     fetchSqlInstances,
-		Multiplex:    client.ProjectMultiplexEnabledAPIs(client.SqlAdminService),
+		Multiplex:    client.ProjectMultiplex,
 		DeleteFilter: client.DeleteProjectFilter,
 		IgnoreError:  client.IgnoreErrorHandler,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"project_id", "name"}},

--- a/resources/services/storage/storage_buckets.go
+++ b/resources/services/storage/storage_buckets.go
@@ -15,7 +15,7 @@ func StorageBuckets() *schema.Table {
 		Name:         "gcp_storage_buckets",
 		Description:  "The Buckets resource represents a bucket in Cloud Storage",
 		Resolver:     fetchStorageBuckets,
-		Multiplex:    client.ProjectMultiplexEnabledAPIs(client.StorageService),
+		Multiplex:    client.ProjectMultiplex,
 		IgnoreError:  client.IgnoreErrorHandler,
 		DeleteFilter: client.DeleteProjectFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"project_id", "id"}},

--- a/resources/services/storage/storage_metrics.go
+++ b/resources/services/storage/storage_metrics.go
@@ -50,7 +50,7 @@ func Metrics() *schema.Table {
 		Name:         "gcp_storage_metrics",
 		Description:  "storage metrics collecting by cloud monitoring service",
 		Resolver:     fetchStorageMetrics,
-		Multiplex:    client.ProjectMultiplexEnabledAPIs(client.StorageService),
+		Multiplex:    client.ProjectMultiplex,
 		IgnoreError:  client.IgnoreErrorHandler,
 		DeleteFilter: client.DeleteProjectFilter,
 		Options:      schema.TableCreationOptions{PrimaryKeys: []string{"project_id", "bucket_name"}},


### PR DESCRIPTION
🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉

#### Summary

Given the current user feedback with big projects this optimization doesn't work as this API is very rate sensitive (it was also throttled and slow in our tests) I suggest to remove this feature completely and only add this as a resource.

The reasoning for this is that this optimization is for accounts with a lot of projects but given it doesn't work for account with alot of projects we rather rollback to the old way which worked for some of our big users.

This feature in itself also brings quite high burden on maintain list of those APIs and also having additional tests to make sure we fetch everything and we multiplex correctly.

The follow-up on this can be just a resource that will fetch just the enabled resource unrelated to that and it will be possible to enable/disable this resource. maybe we can also disable it by default and create a good retry mechanism for that.

---

Use the following steps to ensure your PR is ready to be reviewed

- [ ] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [ ] Run `go fmt` to format your code 🖊
- [ ] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [ ] Update or add tests. Learn more about testing [here](https://docs.cloudquery.io/docs/developers/sdk/testing) 🧪
- [ ] Update the docs by running `go run ./docs/docs.go` and committing the changes 📃
- [ ] If adding a new resource, add [relevant Terraform files](../terraform) in a separate PR 📂
- [ ] Ensure the status checks below are successful ✅
