### PR TITLE
fix: Added check for empty project_id

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -210,6 +210,9 @@ func validateProjects(projects []string) diag.Diagnostics {
 		if project == defaultProjectIdName {
 			return diag.FromError(errors.New("please specify a valid project_id in config.hcl instead of <CHANGE_THIS_TO_YOUR_PROJECT_ID>"), diag.USER)
 		}
+		if project == "" {
+			return diag.FromError(errors.New("please specify a valid project_id in config.hcl instead of empty string"), diag.USER)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
🎉 Thank you for making CloudQuery awesome by submitting a PR 🎉

#### Summary

Added check if project_id is empty string to avoid `googleapi: Error 400: Invalid resource field value in the request.` messages that can appear when empty project id is used.

---

Use the following steps to ensure your PR is ready to be reviewed

- [x] Read the [contribution guidelines](../blob/main/CONTRIBUTING.md) 🧑‍🎓
- [x] Run `go fmt` to format your code 🖊
- [x] Lint your changes via `golangci-lint run` 🚨 (install golangci-lint [here](https://golangci-lint.run/usage/install/#local-installation))
- [x] Update or add tests. Learn more about testing [here](https://docs.cloudquery.io/docs/developers/sdk/testing) 🧪
- [x] Update the docs by running `go run ./docs/docs.go` and committing the changes 📃
- [x] If adding a new resource, add [relevant Terraform files](../terraform) in a separate PR 📂
- [x] Ensure the status checks below are successful ✅
