### PR TITLE
fix: Possible panic

### DIFF
--- a/resources/services/bigquery/bigquery_dataset_tables.go
+++ b/resources/services/bigquery/bigquery_dataset_tables.go
@@ -427,7 +427,8 @@ func listBigqueryDatasetTables(ctx context.Context, meta schema.ClientMeta, pare
 		errs, ctx := errgroup.WithContext(ctx)
 		for _, t := range output.Tables {
 			if err := sem.Acquire(ctx, 1); err != nil {
-				return diag.WrapError(err)
+				// Acquire can only fail if the context is canceled already.  Just exit the loop and allow errs.Wait() to collect the real error.
+				break
 			}
 			func(t *bigquery.TableListTables) {
 				errs.Go(func() error {

--- a/resources/services/cloudbilling/accounts.go
+++ b/resources/services/cloudbilling/accounts.go
@@ -93,7 +93,8 @@ func fetchBillingAccounts(ctx context.Context, meta schema.ClientMeta, parent *s
 		errs, ctx := errgroup.WithContext(ctx)
 		for _, b := range output.BillingAccounts {
 			if err := sem.Acquire(ctx, 1); err != nil {
-				return diag.WrapError(err)
+				// Acquire can only fail if the context is canceled already.  Just exit the loop and allow errs.Wait() to collect the real error.
+				break
 			}
 			func(account cloudbilling.BillingAccount) {
 				errs.Go(func() error {


### PR DESCRIPTION
If one of the goroutines spawned in listBigqueryDatasetTables fails and
returns an error then errgroup.Group.Go will cancel the context.

Then semaphore.Acquire can fail because of the canceled context. After this resolver
finishes, and the SDK closes results channel. But other spawned goroutines can still
be running and they may try to send through this closed channel. Panic.