### PR TITLE
feat: YAML config support

### DIFF
--- a/client/config.go
+++ b/client/config.go
@@ -3,6 +3,7 @@ package client
 import (
 	"time"
 
+	"github.com/cloudquery/cq-provider-sdk/cqproto"
 	"github.com/googleapis/gax-go/v2"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
@@ -11,18 +12,20 @@ import (
 
 // Config defines Provider Configuration
 type Config struct {
-	ProjectFilter         string   `hcl:"project_filter,optional"` // Deprecated
-	ProjectIDs            []string `hcl:"project_ids,optional"`
-	FolderIDs             []string `hcl:"folder_ids,optional"`
-	FolderMaxDepth        uint     `hcl:"folders_max_depth,optional"`
-	ServiceAccountKeyJSON string   `hcl:"service_account_key_json,optional"`
+	ProjectFilter         string   `yaml:"project_filter,omitempty" hcl:"project_filter,optional"` // Deprecated
+	ProjectIDs            []string `yaml:"project_ids,omitempty" hcl:"project_ids,optional"`
+	FolderIDs             []string `yaml:"folder_ids,omitempty" hcl:"folder_ids,optional"`
+	FolderMaxDepth        uint     `yaml:"folders_max_depth,omitempty" hcl:"folders_max_depth,optional"`
+	ServiceAccountKeyJSON string   `yaml:"service_account_key_json,omitempty" hcl:"service_account_key_json,optional"`
 
-	BaseDelay         int     `hcl:"backoff_base_delay,optional" default:"-1"`
-	Multiplier        float64 `hcl:"backoff_multiplier,optional"`
-	MaxDelay          int     `hcl:"backoff_max_delay,optional"`
-	Jitter            float64 `hcl:"backoff_jitter,optional"`
-	MinConnectTimeout int     `hcl:"backoff_min_connect_timeout,optional"`
-	MaxRetries        int     `hcl:"max_retries,optional" default:"3"`
+	BaseDelay         int     `yaml:"backoff_base_delay,omitempty" hcl:"backoff_base_delay,optional" default:"-1"`
+	Multiplier        float64 `yaml:"backoff_multiplier,omitempty" hcl:"backoff_multiplier,optional"`
+	MaxDelay          int     `yaml:"backoff_max_delay,omitempty" hcl:"backoff_max_delay,optional"`
+	Jitter            float64 `yaml:"backoff_jitter,omitempty" hcl:"backoff_jitter,optional"`
+	MinConnectTimeout int     `yaml:"backoff_min_connect_timeout,omitempty" hcl:"backoff_min_connect_timeout,optional"`
+	MaxRetries        int     `yaml:"max_retries,omitempty" hcl:"max_retries,optional" default:"3"`
+
+	requestedFormat cqproto.ConfigFormat
 }
 
 type BackoffSettings struct {
@@ -31,8 +34,16 @@ type BackoffSettings struct {
 	MaxRetries int
 }
 
-func (Config) Example() string {
-	return `configuration {
+func NewConfig(f cqproto.ConfigFormat) *Config {
+	return &Config{
+		requestedFormat: f,
+	}
+}
+
+func (c Config) Example() string {
+	switch c.requestedFormat {
+	case cqproto.ConfigHCL:
+		return `configuration {
 				// Optional. List of folders to get projects from. Required permission: resourcemanager.projects.list
 				// folder_ids = [ "organizations/<ORG_ID>", "folders/<FOLDER_ID>" ]
 				// Optional. Maximum level of folders to recurse into
@@ -50,6 +61,29 @@ func (Config) Example() string {
 				// Optional. Max amount of retries for retrier, defaults to max 3 retries.
 				// max_retries = 3
 			}`
+	default:
+		return `
+  # Optional. List of folders to get projects from. Required permission: resourcemanager.projects.list
+  # folder_ids:
+    # - "organizations/<ORG_ID>"
+    # - "folders/<FOLDER_ID>"
+  # Optional. Maximum level of folders to recurse into
+  # folders_max_depth = 5
+  # Optional. If not specified either using all projects accessible.
+  # project_ids:
+    # - "<CHANGE_THIS_TO_YOUR_PROJECT_ID>"
+  # Optional. ServiceAccountKeyJSON passed as value instead of a file path, can be passed also via env: CQ_SERVICE_ACCOUNT_KEY_JSON
+  # service_account_key_json: <YOUR_JSON_SERVICE_ACCOUNT_KEY_DATA>
+  # Optional. GRPC Retry/backoff configuration, time units in seconds. Documented in https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md
+  # backoff_base_delay: 1
+  # backoff_multiplier: 1.6
+  # backoff_max_delay: 120
+  # backoff_jitter: 0.2
+  # backoff_min_connect_timeout = 0
+  # Optional. Max amount of retries for retrier, defaults to max 3 retries.
+  # max_retries: 3
+`
+	}
 }
 
 func (c Config) ClientOptions() []option.ClientOption {
@@ -90,4 +124,8 @@ func (c Config) Backoff() BackoffSettings {
 	b.Gax.Multiplier = b.Backoff.Multiplier
 
 	return b
+}
+
+func (c Config) Format() cqproto.ConfigFormat {
+	return c.requestedFormat
 }

--- a/client/config.go
+++ b/client/config.go
@@ -68,7 +68,7 @@ func (c Config) Example() string {
     # - "organizations/<ORG_ID>"
     # - "folders/<FOLDER_ID>"
   # Optional. Maximum level of folders to recurse into
-  # folders_max_depth = 5
+  # folders_max_depth: 5
   # Optional. If not specified either using all projects accessible.
   # project_ids:
     # - "<CHANGE_THIS_TO_YOUR_PROJECT_ID>"

--- a/client/config.go
+++ b/client/config.go
@@ -63,25 +63,25 @@ func (c Config) Example() string {
 			}`
 	default:
 		return `
-  # Optional. List of folders to get projects from. Required permission: resourcemanager.projects.list
-  # folder_ids:
-    # - "organizations/<ORG_ID>"
-    # - "folders/<FOLDER_ID>"
-  # Optional. Maximum level of folders to recurse into
-  # folders_max_depth: 5
-  # Optional. If not specified either using all projects accessible.
-  # project_ids:
-    # - "<CHANGE_THIS_TO_YOUR_PROJECT_ID>"
-  # Optional. ServiceAccountKeyJSON passed as value instead of a file path, can be passed also via env: CQ_SERVICE_ACCOUNT_KEY_JSON
-  # service_account_key_json: <YOUR_JSON_SERVICE_ACCOUNT_KEY_DATA>
-  # Optional. GRPC Retry/backoff configuration, time units in seconds. Documented in https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md
-  # backoff_base_delay: 1
-  # backoff_multiplier: 1.6
-  # backoff_max_delay: 120
-  # backoff_jitter: 0.2
-  # backoff_min_connect_timeout = 0
-  # Optional. Max amount of retries for retrier, defaults to max 3 retries.
-  # max_retries: 3
+Optional. List of folders to get projects from. Required permission: resourcemanager.projects.list
+folder_ids:
+  - "organizations/<ORG_ID>"
+  - "folders/<FOLDER_ID>"
+Optional. Maximum level of folders to recurse into
+folders_max_depth: 5
+Optional. If not specified either using all projects accessible.
+project_ids:
+  - "<CHANGE_THIS_TO_YOUR_PROJECT_ID>"
+Optional. ServiceAccountKeyJSON passed as value instead of a file path, can be passed also via env: CQ_SERVICE_ACCOUNT_KEY_JSON
+service_account_key_json: <YOUR_JSON_SERVICE_ACCOUNT_KEY_DATA>
+Optional. GRPC Retry/backoff configuration, time units in seconds. Documented in https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md
+backoff_base_delay: 1
+backoff_multiplier: 1.6
+backoff_max_delay: 120
+backoff_jitter: 0.2
+backoff_min_connect_timeout = 0
+Optional. Max amount of retries for retrier, defaults to max 3 retries.
+max_retries: 3
 `
 	}
 }

--- a/client/testing.go
+++ b/client/testing.go
@@ -3,6 +3,7 @@ package client
 import (
 	"testing"
 
+	"github.com/cloudquery/cq-provider-sdk/cqproto"
 	"github.com/cloudquery/cq-provider-sdk/logging"
 	"github.com/cloudquery/cq-provider-sdk/provider"
 	"github.com/cloudquery/cq-provider-sdk/provider/diag"
@@ -37,8 +38,8 @@ func GcpMockTestHelper(t *testing.T, table *schema.Table, createService func() (
 			ResourceMap: map[string]*schema.Table{
 				"test_resource": table,
 			},
-			Config: func() provider.Config {
-				return &Config{}
+			Config: func(f cqproto.ConfigFormat) provider.Config {
+				return NewConfig(f)
 			},
 		},
 		Config: "",

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudquery/cq-provider-gcp
 go 1.17
 
 require (
-	github.com/cloudquery/cq-provider-sdk v0.11.5-0.20220620152032-10cf9e9d7075
+	github.com/cloudquery/cq-provider-sdk v0.11.5-0.20220620173035-3bb85f127be0
 	github.com/cloudquery/faker/v3 v3.7.5
 	github.com/googleapis/gax-go/v2 v2.1.1
 	github.com/hashicorp/go-hclog v1.2.1

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudquery/cq-provider-gcp
 go 1.17
 
 require (
-	github.com/cloudquery/cq-provider-sdk v0.11.4
+	github.com/cloudquery/cq-provider-sdk v0.11.5-0.20220620123658-0dcdd27f34c9
 	github.com/cloudquery/faker/v3 v3.7.5
 	github.com/googleapis/gax-go/v2 v2.1.1
 	github.com/hashicorp/go-hclog v1.2.1

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudquery/cq-provider-gcp
 go 1.17
 
 require (
-	github.com/cloudquery/cq-provider-sdk v0.12.0
+	github.com/cloudquery/cq-provider-sdk v0.12.1
 	github.com/cloudquery/faker/v3 v3.7.5
 	github.com/googleapis/gax-go/v2 v2.1.1
 	github.com/hashicorp/go-hclog v1.2.1

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudquery/cq-provider-gcp
 go 1.17
 
 require (
-	github.com/cloudquery/cq-provider-sdk v0.11.5-0.20220620174349-3573c7883193
+	github.com/cloudquery/cq-provider-sdk v0.12.0
 	github.com/cloudquery/faker/v3 v3.7.5
 	github.com/googleapis/gax-go/v2 v2.1.1
 	github.com/hashicorp/go-hclog v1.2.1

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudquery/cq-provider-gcp
 go 1.17
 
 require (
-	github.com/cloudquery/cq-provider-sdk v0.11.5-0.20220620173035-3bb85f127be0
+	github.com/cloudquery/cq-provider-sdk v0.11.5-0.20220620174349-3573c7883193
 	github.com/cloudquery/faker/v3 v3.7.5
 	github.com/googleapis/gax-go/v2 v2.1.1
 	github.com/hashicorp/go-hclog v1.2.1

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudquery/cq-provider-gcp
 go 1.17
 
 require (
-	github.com/cloudquery/cq-provider-sdk v0.11.5-0.20220620140341-c19204efe90c
+	github.com/cloudquery/cq-provider-sdk v0.11.5-0.20220620152032-10cf9e9d7075
 	github.com/cloudquery/faker/v3 v3.7.5
 	github.com/googleapis/gax-go/v2 v2.1.1
 	github.com/hashicorp/go-hclog v1.2.1

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cloudquery/cq-provider-gcp
 go 1.17
 
 require (
-	github.com/cloudquery/cq-provider-sdk v0.11.5-0.20220620123658-0dcdd27f34c9
+	github.com/cloudquery/cq-provider-sdk v0.11.5-0.20220620140341-c19204efe90c
 	github.com/cloudquery/faker/v3 v3.7.5
 	github.com/googleapis/gax-go/v2 v2.1.1
 	github.com/hashicorp/go-hclog v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/cloudquery/cq-provider-sdk v0.11.4 h1:/y/AB+/mKRGFoc0rLin3KRtfqc5eAoo
 github.com/cloudquery/cq-provider-sdk v0.11.4/go.mod h1:q6hYy9S+XtKG8cyOiLG5gqSIkXEJ72MHQ316zW6DMiA=
 github.com/cloudquery/cq-provider-sdk v0.11.5-0.20220620123658-0dcdd27f34c9 h1:BpJjOGMMMw/qSUj7uKqKMpAKt/KlSJLMuQV5MjU+8Og=
 github.com/cloudquery/cq-provider-sdk v0.11.5-0.20220620123658-0dcdd27f34c9/go.mod h1:o5czsmX3MeP8cY/KtabkqavkS7asF8HwFAO1n5+CvoQ=
+github.com/cloudquery/cq-provider-sdk v0.11.5-0.20220620140341-c19204efe90c h1:S36Piy7EtW2I0gL5kJKta+ClyHNaE2089krLHhWzrOM=
+github.com/cloudquery/cq-provider-sdk v0.11.5-0.20220620140341-c19204efe90c/go.mod h1:o5czsmX3MeP8cY/KtabkqavkS7asF8HwFAO1n5+CvoQ=
 github.com/cloudquery/faker/v3 v3.7.5 h1:G7ANdEEcm8TvAAjIwNWSLrYK36CFCiSlrCqOTGCccL0=
 github.com/cloudquery/faker/v3 v3.7.5/go.mod h1:1b8WVG9Gh0T2hVo1a8dWeXfu0AhqSB6J/mmJaesqOeo=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudquery/cq-provider-sdk v0.11.5-0.20220620173035-3bb85f127be0 h1:oZuVHjPxXgqGNh3VsNy7hWAtJO0JhpQXDo7QN+NRKQw=
-github.com/cloudquery/cq-provider-sdk v0.11.5-0.20220620173035-3bb85f127be0/go.mod h1:o5czsmX3MeP8cY/KtabkqavkS7asF8HwFAO1n5+CvoQ=
+github.com/cloudquery/cq-provider-sdk v0.11.5-0.20220620174349-3573c7883193 h1:tmvzuAgNADf4isij+nvl+EXh5OdpPSA2gDU4LwFtbss=
+github.com/cloudquery/cq-provider-sdk v0.11.5-0.20220620174349-3573c7883193/go.mod h1:o5czsmX3MeP8cY/KtabkqavkS7asF8HwFAO1n5+CvoQ=
 github.com/cloudquery/faker/v3 v3.7.5 h1:G7ANdEEcm8TvAAjIwNWSLrYK36CFCiSlrCqOTGCccL0=
 github.com/cloudquery/faker/v3 v3.7.5/go.mod h1:1b8WVG9Gh0T2hVo1a8dWeXfu0AhqSB6J/mmJaesqOeo=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,8 @@ github.com/cloudquery/cq-provider-sdk v0.11.5-0.20220620123658-0dcdd27f34c9 h1:B
 github.com/cloudquery/cq-provider-sdk v0.11.5-0.20220620123658-0dcdd27f34c9/go.mod h1:o5czsmX3MeP8cY/KtabkqavkS7asF8HwFAO1n5+CvoQ=
 github.com/cloudquery/cq-provider-sdk v0.11.5-0.20220620140341-c19204efe90c h1:S36Piy7EtW2I0gL5kJKta+ClyHNaE2089krLHhWzrOM=
 github.com/cloudquery/cq-provider-sdk v0.11.5-0.20220620140341-c19204efe90c/go.mod h1:o5czsmX3MeP8cY/KtabkqavkS7asF8HwFAO1n5+CvoQ=
+github.com/cloudquery/cq-provider-sdk v0.11.5-0.20220620152032-10cf9e9d7075 h1:8MPdDD9nnXrlDMmXOk9cuRYpf0plPJmHisH4pLM1YsU=
+github.com/cloudquery/cq-provider-sdk v0.11.5-0.20220620152032-10cf9e9d7075/go.mod h1:o5czsmX3MeP8cY/KtabkqavkS7asF8HwFAO1n5+CvoQ=
 github.com/cloudquery/faker/v3 v3.7.5 h1:G7ANdEEcm8TvAAjIwNWSLrYK36CFCiSlrCqOTGCccL0=
 github.com/cloudquery/faker/v3 v3.7.5/go.mod h1:1b8WVG9Gh0T2hVo1a8dWeXfu0AhqSB6J/mmJaesqOeo=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudquery/cq-provider-sdk v0.11.5-0.20220620152032-10cf9e9d7075 h1:8MPdDD9nnXrlDMmXOk9cuRYpf0plPJmHisH4pLM1YsU=
-github.com/cloudquery/cq-provider-sdk v0.11.5-0.20220620152032-10cf9e9d7075/go.mod h1:o5czsmX3MeP8cY/KtabkqavkS7asF8HwFAO1n5+CvoQ=
+github.com/cloudquery/cq-provider-sdk v0.11.5-0.20220620173035-3bb85f127be0 h1:oZuVHjPxXgqGNh3VsNy7hWAtJO0JhpQXDo7QN+NRKQw=
+github.com/cloudquery/cq-provider-sdk v0.11.5-0.20220620173035-3bb85f127be0/go.mod h1:o5czsmX3MeP8cY/KtabkqavkS7asF8HwFAO1n5+CvoQ=
 github.com/cloudquery/faker/v3 v3.7.5 h1:G7ANdEEcm8TvAAjIwNWSLrYK36CFCiSlrCqOTGCccL0=
 github.com/cloudquery/faker/v3 v3.7.5/go.mod h1:1b8WVG9Gh0T2hVo1a8dWeXfu0AhqSB6J/mmJaesqOeo=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudquery/cq-provider-sdk v0.12.0 h1:S3AAkxmXhoGwvn7E77GmcOzkIFAxOjXEhPr+F0jW+Pg=
-github.com/cloudquery/cq-provider-sdk v0.12.0/go.mod h1:o5czsmX3MeP8cY/KtabkqavkS7asF8HwFAO1n5+CvoQ=
+github.com/cloudquery/cq-provider-sdk v0.12.1 h1:Y4/VWjb/HLRX1pUoA7H82JoEu5mizNCDlfIeLGXOXSA=
+github.com/cloudquery/cq-provider-sdk v0.12.1/go.mod h1:o5czsmX3MeP8cY/KtabkqavkS7asF8HwFAO1n5+CvoQ=
 github.com/cloudquery/faker/v3 v3.7.5 h1:G7ANdEEcm8TvAAjIwNWSLrYK36CFCiSlrCqOTGCccL0=
 github.com/cloudquery/faker/v3 v3.7.5/go.mod h1:1b8WVG9Gh0T2hVo1a8dWeXfu0AhqSB6J/mmJaesqOeo=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMn
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudquery/cq-provider-sdk v0.11.4 h1:/y/AB+/mKRGFoc0rLin3KRtfqc5eAooYjqdltrsGi8I=
 github.com/cloudquery/cq-provider-sdk v0.11.4/go.mod h1:q6hYy9S+XtKG8cyOiLG5gqSIkXEJ72MHQ316zW6DMiA=
+github.com/cloudquery/cq-provider-sdk v0.11.5-0.20220620123658-0dcdd27f34c9 h1:BpJjOGMMMw/qSUj7uKqKMpAKt/KlSJLMuQV5MjU+8Og=
+github.com/cloudquery/cq-provider-sdk v0.11.5-0.20220620123658-0dcdd27f34c9/go.mod h1:o5czsmX3MeP8cY/KtabkqavkS7asF8HwFAO1n5+CvoQ=
 github.com/cloudquery/faker/v3 v3.7.5 h1:G7ANdEEcm8TvAAjIwNWSLrYK36CFCiSlrCqOTGCccL0=
 github.com/cloudquery/faker/v3 v3.7.5/go.mod h1:1b8WVG9Gh0T2hVo1a8dWeXfu0AhqSB6J/mmJaesqOeo=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=

--- a/go.sum
+++ b/go.sum
@@ -68,12 +68,6 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudquery/cq-provider-sdk v0.11.4 h1:/y/AB+/mKRGFoc0rLin3KRtfqc5eAooYjqdltrsGi8I=
-github.com/cloudquery/cq-provider-sdk v0.11.4/go.mod h1:q6hYy9S+XtKG8cyOiLG5gqSIkXEJ72MHQ316zW6DMiA=
-github.com/cloudquery/cq-provider-sdk v0.11.5-0.20220620123658-0dcdd27f34c9 h1:BpJjOGMMMw/qSUj7uKqKMpAKt/KlSJLMuQV5MjU+8Og=
-github.com/cloudquery/cq-provider-sdk v0.11.5-0.20220620123658-0dcdd27f34c9/go.mod h1:o5czsmX3MeP8cY/KtabkqavkS7asF8HwFAO1n5+CvoQ=
-github.com/cloudquery/cq-provider-sdk v0.11.5-0.20220620140341-c19204efe90c h1:S36Piy7EtW2I0gL5kJKta+ClyHNaE2089krLHhWzrOM=
-github.com/cloudquery/cq-provider-sdk v0.11.5-0.20220620140341-c19204efe90c/go.mod h1:o5czsmX3MeP8cY/KtabkqavkS7asF8HwFAO1n5+CvoQ=
 github.com/cloudquery/cq-provider-sdk v0.11.5-0.20220620152032-10cf9e9d7075 h1:8MPdDD9nnXrlDMmXOk9cuRYpf0plPJmHisH4pLM1YsU=
 github.com/cloudquery/cq-provider-sdk v0.11.5-0.20220620152032-10cf9e9d7075/go.mod h1:o5czsmX3MeP8cY/KtabkqavkS7asF8HwFAO1n5+CvoQ=
 github.com/cloudquery/faker/v3 v3.7.5 h1:G7ANdEEcm8TvAAjIwNWSLrYK36CFCiSlrCqOTGCccL0=

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
-github.com/cloudquery/cq-provider-sdk v0.11.5-0.20220620174349-3573c7883193 h1:tmvzuAgNADf4isij+nvl+EXh5OdpPSA2gDU4LwFtbss=
-github.com/cloudquery/cq-provider-sdk v0.11.5-0.20220620174349-3573c7883193/go.mod h1:o5czsmX3MeP8cY/KtabkqavkS7asF8HwFAO1n5+CvoQ=
+github.com/cloudquery/cq-provider-sdk v0.12.0 h1:S3AAkxmXhoGwvn7E77GmcOzkIFAxOjXEhPr+F0jW+Pg=
+github.com/cloudquery/cq-provider-sdk v0.12.0/go.mod h1:o5czsmX3MeP8cY/KtabkqavkS7asF8HwFAO1n5+CvoQ=
 github.com/cloudquery/faker/v3 v3.7.5 h1:G7ANdEEcm8TvAAjIwNWSLrYK36CFCiSlrCqOTGCccL0=
 github.com/cloudquery/faker/v3 v3.7.5/go.mod h1:1b8WVG9Gh0T2hVo1a8dWeXfu0AhqSB6J/mmJaesqOeo=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=

--- a/resources/provider/provider.go
+++ b/resources/provider/provider.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cloudquery/cq-provider-gcp/resources/services/resource_manager"
 	"github.com/cloudquery/cq-provider-gcp/resources/services/sql"
 	"github.com/cloudquery/cq-provider-gcp/resources/services/storage"
+	"github.com/cloudquery/cq-provider-sdk/cqproto"
 	"github.com/cloudquery/cq-provider-sdk/provider"
 	"github.com/cloudquery/cq-provider-sdk/provider/schema"
 )
@@ -73,8 +74,8 @@ func Provider() *provider.Provider {
 			"bigquery.datasets":     bigquery.BigqueryDatasets(),
 			"kubernetes.clusters":   kubernetes.Clusters(),
 		},
-		Config: func() provider.Config {
-			return &client.Config{}
+		Config: func(f cqproto.ConfigFormat) provider.Config {
+			return client.NewConfig(f)
 		},
 	}
 }


### PR DESCRIPTION
to go with [cloudquery/cq-provider-sdk](https://github.com/cloudquery/cq-provider-sdk) and https://github.com/cloudquery/cloudquery/pull/887

`go run main.go init gcp --config config.yml` creates this:
```yaml
cloudquery:
    providers:
        - name: gcp
          version: latest
    connection:
        type: postgres
        username: postgres
        password: pass
        host: localhost
        port: 5432
        database: postgres
        sslmode: disable
providers:
    # provider configurations
    - name: gcp
      # Optional. List of folders to get projects from. Required permission: resourcemanager.projects.list
      # folder_ids:
      #   - "organizations/<ORG_ID>"
      #   - "folders/<FOLDER_ID>"
      # Optional. Maximum level of folders to recurse into
      # folders_max_depth: 5
      # Optional. If not specified either using all projects accessible.
      # project_ids:
      #   - "<CHANGE_THIS_TO_YOUR_PROJECT_ID>"
      # Optional. ServiceAccountKeyJSON passed as value instead of a file path, can be passed also via env: CQ_SERVICE_ACCOUNT_KEY_JSON
      # service_account_key_json: <YOUR_JSON_SERVICE_ACCOUNT_KEY_DATA>
      # Optional. GRPC Retry/backoff configuration, time units in seconds. Documented in https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md
      # backoff_base_delay: 1
      # backoff_multiplier: 1.6
      # backoff_max_delay: 120
      # backoff_jitter: 0.2
      # backoff_min_connect_timeout = 0
      # Optional. Max amount of retries for retrier, defaults to max 3 retries.
      # max_retries: 3
      #  
      # list of resources to fetch
      resources:
        - bigquery.datasets
        - cloudbilling.accounts
#...
```