### PR TITLE
feat: Use 'unavailable' for resources without region in resources view

### DIFF
--- a/views/resource.sql
+++ b/views/resource.sql
@@ -17,7 +17,7 @@ select table_name from information_schema.columns where table_name like 'gcp_%s'
 	 strSQL = strSQL || format('select  cq_id,  cq_meta, %L as cq_table, project_id, %s as region, id, %s as name, %s as description,
 		  					    COALESCE(%s, (cq_meta->>''last_updated'')::timestamp) as fetch_date
 							   FROM %s', tbl,
-							   CASE WHEN EXISTS (SELECT 1 FROM information_schema.columns WHERE column_name='region' AND table_name=tbl) THEN 'region' ELSE 'NULL' END,
+							   CASE WHEN EXISTS (SELECT 1 FROM information_schema.columns WHERE column_name='region' AND table_name=tbl) THEN 'region' ELSE E'\'unavailable\'' END,
                                CASE WHEN EXISTS (SELECT 1 FROM information_schema.columns WHERE column_name='name' AND table_name=tbl) THEN 'name' ELSE 'NULL' END,
                                CASE WHEN EXISTS (SELECT 1 FROM information_schema.columns WHERE column_name='description' AND table_name=tbl) THEN 'description' ELSE 'NULL' END,
 							   CASE WHEN EXISTS (SELECT 1 FROM information_schema.columns WHERE column_name='fetch_date' AND table_name=tbl) THEN 'fetch_date' ELSE 'NULL::timestamp' END,


### PR DESCRIPTION
In order to better work with Grafana dashboards, the resources view should set the location to `unavailable` for resources that don't have a specific region (for example, resources that are global). Otherwise, region-less resources will be excluded by queries when the Regions variable is set to "All". Unfortunately, there doesn't seem to be a better way in which we can handle this directly in Grafana.

Related to https://github.com/cloudquery/dashboards/pull/22