### PR TITLE
chore(tests): Add Terraform for Cloudrun services

### DIFF
--- a/terraform/cloudrun/local/main.tf
+++ b/terraform/cloudrun/local/main.tf
@@ -1,0 +1,5 @@
+module "test" {
+    source = "../modules/test"
+    prefix = var.prefix
+    project_id = var.project_id
+}

--- a/terraform/cloudrun/local/variables.tf
+++ b/terraform/cloudrun/local/variables.tf
@@ -1,0 +1,12 @@
+variable "prefix" {
+  description = "Prefix to use for all name resources"
+  type        = string
+  validation {
+    condition     = length(var.prefix) == 2
+    error_message = "The prefix should be exactly two characters."
+  }
+}
+
+variable "project_id" {
+  description = "Project where test resources will be deployed."
+}

--- a/terraform/cloudrun/modules/test/cloudrun.tf
+++ b/terraform/cloudrun/modules/test/cloudrun.tf
@@ -2,6 +2,28 @@
 # Cloud Run Module
 ################################################################################
 
+data "google_project" "project" {
+}
+
+resource "google_secret_manager_secret" "secret" {
+  secret_id = "${lower(var.prefix)}-cloudrun-secret"
+  replication {
+    automatic = true
+  }
+}
+
+resource "google_secret_manager_secret_version" "secret-version-data" {
+  secret = google_secret_manager_secret.secret.name
+  secret_data = "secret-data"
+}
+
+resource "google_secret_manager_secret_iam_member" "secret-access" {
+  secret_id = google_secret_manager_secret.secret.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${data.google_project.project.number}-compute@developer.gserviceaccount.com"
+  depends_on = [google_secret_manager_secret.secret]
+}
+
 resource "google_cloud_run_service" "default" {
   name     = "${lower(var.prefix)}-cloudrun-srv"
   location = "us-central1"
@@ -10,20 +32,52 @@ resource "google_cloud_run_service" "default" {
     spec {
       containers {
         image = "us-docker.pkg.dev/cloudrun/container/hello"
+        volume_mounts {
+          name = "a-volume"
+          mount_path = "/secrets"
+        }
         env {
           name = "ENV_VAR"
           value = "test"
         }
+        env {
+          name = "SECRET_ENV_VAR"
+          value_from {
+            secret_key_ref {
+              name = google_secret_manager_secret.secret.secret_id
+              key = "1"
+            }
+          }
+        }
+      }
+      volumes {
+        name = "a-volume"
+        secret {
+          secret_name = google_secret_manager_secret.secret.secret_id
+          default_mode = 292 # 0444
+          items {
+            key = "1"
+            path = "my-secret"
+            mode = 256 # 0400
+          }
+        }
       }
     }
     metadata {
-      name = "${lower(var.prefix)}-cloudrun-srv-green"
+      annotations = {
+        "autoscaling.knative.dev/maxScale"      = "1"
+        "run.googleapis.com/client-name"        = "terraform"
+      }
     }
   }
 
   metadata {
     annotations = {
       generated-by = "magic-modules"
+      "run.googleapis.com/ingress" = "internal"
+    }
+    labels = {
+      key = "value"
     }
   }
 
@@ -31,11 +85,7 @@ resource "google_cloud_run_service" "default" {
     percent         = 100
     latest_revision = true
   }
-  autogenerate_revision_name = false
+  autogenerate_revision_name = true
 
-  lifecycle {
-    ignore_changes = [
-      metadata.0.annotations,
-    ]
-  }
+  depends_on = [google_secret_manager_secret_version.secret-version-data]
 }

--- a/terraform/cloudrun/modules/test/cloudrun.tf
+++ b/terraform/cloudrun/modules/test/cloudrun.tf
@@ -32,6 +32,14 @@ resource "google_cloud_run_service" "default" {
     spec {
       containers {
         image = "us-docker.pkg.dev/cloudrun/container/hello"
+        command = ["/server"]
+        resources {
+          limits = {
+            cpu = "1000m"
+            memory = "512Mi"
+          }
+          requests = {}
+        }
         volume_mounts {
           name = "a-volume"
           mount_path = "/secrets"
@@ -67,6 +75,9 @@ resource "google_cloud_run_service" "default" {
       annotations = {
         "autoscaling.knative.dev/maxScale"      = "1"
         "run.googleapis.com/client-name"        = "terraform"
+      }
+      labels = {
+        "key" = "value"
       }
     }
   }

--- a/terraform/cloudrun/modules/test/cloudrun.tf
+++ b/terraform/cloudrun/modules/test/cloudrun.tf
@@ -10,12 +10,32 @@ resource "google_cloud_run_service" "default" {
     spec {
       containers {
         image = "us-docker.pkg.dev/cloudrun/container/hello"
+        env {
+          name = "ENV_VAR"
+          value = "test"
+        }
       }
+    }
+    metadata {
+      name = "${lower(var.prefix)}-cloudrun-srv-green"
+    }
+  }
+
+  metadata {
+    annotations = {
+      generated-by = "magic-modules"
     }
   }
 
   traffic {
     percent         = 100
     latest_revision = true
+  }
+  autogenerate_revision_name = false
+
+  lifecycle {
+    ignore_changes = [
+      metadata.0.annotations,
+    ]
   }
 }

--- a/terraform/cloudrun/modules/test/cloudrun.tf
+++ b/terraform/cloudrun/modules/test/cloudrun.tf
@@ -1,0 +1,21 @@
+################################################################################
+# Cloud Run Module
+################################################################################
+
+resource "google_cloud_run_service" "default" {
+  name     = "${lower(var.prefix)}-cloudrun-srv"
+  location = "us-central1"
+
+  template {
+    spec {
+      containers {
+        image = "us-docker.pkg.dev/cloudrun/container/hello"
+      }
+    }
+  }
+
+  traffic {
+    percent         = 100
+    latest_revision = true
+  }
+}

--- a/terraform/cloudrun/modules/test/providers.tf
+++ b/terraform/cloudrun/modules/test/providers.tf
@@ -1,0 +1,4 @@
+provider "google" {
+    project = var.project_id
+    region  = var.region
+}

--- a/terraform/cloudrun/modules/test/terraform.tf
+++ b/terraform/cloudrun/modules/test/terraform.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 0.15"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.14.0"
+    }
+  }
+}

--- a/terraform/cloudrun/modules/test/variables.tf
+++ b/terraform/cloudrun/modules/test/variables.tf
@@ -1,0 +1,24 @@
+variable "prefix" {
+  description = "Prefix to use for all name resources"
+  type        = string
+  validation {
+    condition     = length(var.prefix) == 2
+    error_message = "The prefix should be exactly two characters."
+  }
+}
+
+variable "project_id" {
+  description = "Project where test resources will be deployed."
+}
+
+variable "region" {
+  description = "Region where test resources will be deployed."
+  default    = "us-east1"
+}
+
+variable "labels" {
+  type = map
+  default = {
+    "environment" = "cq-provider-gcp"
+  }
+}

--- a/terraform/cloudrun/prod/main.tf
+++ b/terraform/cloudrun/prod/main.tf
@@ -1,0 +1,5 @@
+module "test" {
+  source = "../modules/test"
+  prefix = "cq"
+  project_id = "cq-provider-gcp"
+}

--- a/terraform/cloudrun/prod/terraform.tf
+++ b/terraform/cloudrun/prod/terraform.tf
@@ -1,0 +1,6 @@
+terraform {
+  backend "gcs" {
+    bucket = "cq-provider-gcp-tf-state"
+    prefix = "cloudrun"
+  }
+}


### PR DESCRIPTION
Adds Terraform for Cloud Run services that can be used in integration tests. Required for https://github.com/cloudquery/cq-provider-gcp/pull/411