### PR TITLE
fix(tests): Enable APIs needed for Cloud Run

### DIFF
--- a/terraform/cloudrun/modules/test/cloudrun.tf
+++ b/terraform/cloudrun/modules/test/cloudrun.tf
@@ -5,6 +5,18 @@
 data "google_project" "project" {
 }
 
+resource "google_project_service" "cloudrun" {
+  project = data.google_project.project.project_id
+  service = "run.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "secretmanager" {
+  project = data.google_project.project.project_id
+  service = "secretmanager.googleapis.com"
+  disable_on_destroy = false
+}
+
 resource "google_secret_manager_secret" "secret" {
   secret_id = "${lower(var.prefix)}-cloudrun-secret"
   replication {


### PR DESCRIPTION
The Cloud Run terraform requires two APIs to be enabled: Secret Manager API and Cloud Run API itself. This change turns these APIs on via Terraform. 

I have decided to set `disable_on_destroy = false` since these APIs are essentially on/off singletons, and we don't know if other services also rely on the same APIs. We also use prefixes in the same project, and don't want these APIs to be turned off if the resources for one prefix gets destroyed. Please let me know if you can think of a better way to do this!